### PR TITLE
Update settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,6 @@
     "python.testing.pytestArgs": [
         "."
     ],
-    "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
+    "python.testing.unittestEnabled": true,
+    "python.testing.pytestEnabled": false
 }


### PR DESCRIPTION
Perche nel setting unittest è impostato a false? poi non la usiamo nel file di test ?  Nel mio fork li ho invertiti per far partire i test. Altrimenti partendo quelli di pytest non li riconosceva. Utilizzo VSCode